### PR TITLE
Updated versions in cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,8 @@ edition = "2018"
 [dependencies]
 num-traits="0.2"
 ndarray = "0.14.0"
-lapack = "0.16.0"
-#blas = "0.21.0"
-#num-complex="0.3" currently limited by BLAS which uses lower version
-blas = { git = "https://github.com/blas-lapack-rs/blas.git", version = "0.21.0" }
+lapack = "0.17.0"
+blas = "0.21.0"
+num-complex="0.3" 
 openblas-src = "0.10.2"
 

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -7,12 +7,13 @@ use lapack::{strtrs,dtrtrs,ctrtrs,ztrtrs};
 // LAPACK householder reflector routines
 use lapack::{sormqr,dormqr,cunmqr,zunmqr};
 use num_traits::{Float,Zero};
+use num_complex::Complex;
 
 
-use lapack::c32;
-use lapack::c64;
-type C32=c32;
-type C64=c64;
+//use lapack::c32;
+//use lapack::c64;
+type C32=Complex<f32>;
+type C64=Complex<f64>;
 
 fn check_if_fortran_style<F>(a : &Array2<F>) -> Option<()>{
     let strides=a.strides();


### PR DESCRIPTION
Upgrading BLAS an LAPACK crates so that they depend on the most recent version of `num-complex`